### PR TITLE
Additional pop-up regarding Protecting the account.

### DIFF
--- a/Instructions/00.md
+++ b/Instructions/00.md
@@ -22,10 +22,12 @@
 3. Now enter the following password and click on **Sign in**.
    * Password: <inject key="AzureAdUserPassword"></inject>
 
-4. If you see the pop-up **Stay Signed in?**, click Yes
+4. If you see the pop-up **Help us protect your account**, click **Skip for now**
 
-5. If you see the pop-up **You have free Azure Advisor recommendations!**, close the window and continue.
+5. If you see the pop-up **Stay Signed in?**, click Yes
 
-6. If a **Welcome to Microsoft Azure** popup window appears, click **Maybe Later** to skip the tour.
+6. If you see the pop-up **You have free Azure Advisor recommendations!**, close the window and continue.
 
-7. Click on **Next** from the bottom right corner of the lab guide.
+7. If a **Welcome to Microsoft Azure** popup window appears, click **Maybe Later** to skip the tour.
+
+8. Click on **Next** from the bottom right corner of the lab guide.


### PR DESCRIPTION
Instead of clicking Next the user should click "Skip for now" so that it doesn't try to enable MFA for the account.